### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: common-lisp
+sudo: required
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
-       -e '(ql:quickload :commonqt)'
+       -e '(ql:quickload :qt)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ script:
                    (declare (ignore c h))
                    (uiop:quit -1)))'
        -e '(ql:quickload :qt)'
+       -e '(ql:quickload :qt-test)'
+       -e '(rt:run-tests)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
   - sudo apt-get install libqt4-dev libsmokeqtgui4-3 libsmokeqt4-dev
 
 script:
-  - cl -e '(setf *debugger-hook*
+  - cl -e '(ql:quickload :trivial-features)'
+       -e '(setf *debugger-hook*
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
                    (uiop:quit -1)))'
        -e '(ql:quickload :qt)'
        -e '(ql:quickload :qt-test)'
-       -e '(rt:run-tests)'
+       -e '(rt:do-tests)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: common-lisp
+
+env:
+  matrix:
+    - LISP=sbcl
+
+install:
+  # Install cl-travis
+  - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+
+script:
+  - cl -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(ql:quickload :qt-test)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
-       -e '(ql:quickload :qt-test)'
+       -e '(ql:quickload :qt)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
-       -e '(ql:quickload :commonqt')
+       -e '(ql:quickload :commonqt)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
   # Install Qt dependencies
   - sudo apt-get install libqt4-dev libsmokeqtgui4-3 libsmokeqt4-dev
+  # Set up a virtual X framebuffer
+  - sudo apt-get install xvfb
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb time to start
 
 script:
   - cl -e '(ql:quickload :trivial-features)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
                  (lambda (c h)
                    (declare (ignore c h))
                    (uiop:quit -1)))'
-       -e '(ql:quickload :qt)'
+       -e '(ql:quickload :commonqt')

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
 install:
   # Install cl-travis
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+  # Install Qt dependencies
+  - sudo apt-get install libqt4-dev libsmokeqtgui4-3 libsmokeqt4-dev
 
 script:
   - cl -e '(setf *debugger-hook*


### PR DESCRIPTION
This PR adds a `.travis.yml` file to build and test CommonQt on the cloud. It sets up an X server with a virtual framebuffer to ensure the tests actually run. 

The tests are run on all pull requests and most commits to ensure changes don't breaks anything.

Note, you need to sign into Travis with GitHub and enable running builds on this repository for this to work.