### PR TITLE
Incorporate Qt-libs as the loading mechanism for the shared libraries

### DIFF
--- a/ffi.lisp
+++ b/ffi.lisp
@@ -32,29 +32,24 @@
 (defvar *library-loaded-p* nil)
 
 (defun load-libcommonqt ()
-  ;; Workaround for Qt+SBCL SIGCHLD handler conflict.
-  ;; In its SIGCHLD handler Qt invokes the old handler with
-  ;; signal argument only, so in case when SA_SIGINFO is used
-  ;; it receives bad values as its siginfo and context
-  ;; arguments. In case of SBCL this causes memory fault
-  ;; e.g. when using SB-EXT:RUN-PROGRAM. Here we disable
-  ;; the handler that causes that fault (SB-EXT:RUN-PROGRAM
-  ;; still works after that). Thanks to nyef on #lisp.
-  ;; See also: src/corelib/io/qprocess_unix.cpp in Qt
-  #+(and sbcl (not windows))
-  (sb-sys:enable-interrupt sb-unix:sigchld :default)
-  (cffi:load-foreign-library
-   (let ((lib (make-pathname :name #-windows "libcommonqt"
-                                   #+windows "commonqt"
-                             :type #+darwin "dylib"
-                                   #+windows "dll"
-                                   #-(or darwin windows) "so"
-                             :defaults #.(or *compile-file-truename*
-                                             *load-truename*))))
-     (if (probe-file lib)
-         (namestring lib)
-         (file-namestring lib))))
-  (setf *library-loaded-p* t))
+  (unless *library-loaded-p*
+    ;; Workaround for Qt+SBCL SIGCHLD handler conflict.
+    ;; In its SIGCHLD handler Qt invokes the old handler with
+    ;; signal argument only, so in case when SA_SIGINFO is used
+    ;; it receives bad values as its siginfo and context
+    ;; arguments. In case of SBCL this causes memory fault
+    ;; e.g. when using SB-EXT:RUN-PROGRAM. Here we disable
+    ;; the handler that causes that fault (SB-EXT:RUN-PROGRAM
+    ;; still works after that). Thanks to nyef on #lisp.
+    ;; See also: src/corelib/io/qprocess_unix.cpp in Qt
+    #+(and sbcl (not windows))
+    (sb-sys:enable-interrupt sb-unix:sigchld :default)
+    ;; Load the required libraries in their proper order.
+    (load-library #-windows "QtCore" #+windows "QtCore4")
+    (load-library #-windows "QtGui" #+windows "QtGui4")
+    (load-library "smokebase")
+    (load-library "commonqt")
+    (setf *library-loaded-p* t)))
 
 #-(or ecl ccl (and sbcl linkage-table))
 (load-libcommonqt)

--- a/ffi.lisp
+++ b/ffi.lisp
@@ -44,10 +44,6 @@
     ;; See also: src/corelib/io/qprocess_unix.cpp in Qt
     #+(and sbcl (not windows))
     (sb-sys:enable-interrupt sb-unix:sigchld :default)
-    ;; Load the required libraries in their proper order.
-    (load-library #-windows "QtCore" #+windows "QtCore4")
-    (load-library #-windows "QtGui" #+windows "QtGui4")
-    (load-library "smokebase")
     (load-library "commonqt")
     (setf *library-loaded-p* t)))
 

--- a/ffi.lisp
+++ b/ffi.lisp
@@ -32,26 +32,29 @@
 (defvar *library-loaded-p* nil)
 
 (defun load-libcommonqt ()
-  (unless *library-loaded-p*
-    ;; Workaround for Qt+SBCL SIGCHLD handler conflict.
-    ;; In its SIGCHLD handler Qt invokes the old handler with
-    ;; signal argument only, so in case when SA_SIGINFO is used
-    ;; it receives bad values as its siginfo and context
-    ;; arguments. In case of SBCL this causes memory fault
-    ;; e.g. when using SB-EXT:RUN-PROGRAM. Here we disable
-    ;; the handler that causes that fault (SB-EXT:RUN-PROGRAM
-    ;; still works after that). Thanks to nyef on #lisp.
-    ;; See also: src/corelib/io/qprocess_unix.cpp in Qt
-    #+(and sbcl (not windows))
-    (sb-sys:enable-interrupt sb-unix:sigchld :default)
-    ;; Do the loading.
-    (qt-libs:ensure-lib-loaded #-windows "QtCore" #+windows "QtCore4")
-    (qt-libs:ensure-lib-loaded #-windows "QtGui" #+windows "QtGui4")
-    (qt-libs:ensure-lib-loaded "smokebase")
-    (qt-libs:ensure-lib-loaded "smokeqtcore")
-    (qt-libs:ensure-lib-loaded "smokeqtgui")
-    (qt-libs:ensure-lib-loaded "commonqt")
-    (setf *library-loaded-p* t)))
+  ;; Workaround for Qt+SBCL SIGCHLD handler conflict.
+  ;; In its SIGCHLD handler Qt invokes the old handler with
+  ;; signal argument only, so in case when SA_SIGINFO is used
+  ;; it receives bad values as its siginfo and context
+  ;; arguments. In case of SBCL this causes memory fault
+  ;; e.g. when using SB-EXT:RUN-PROGRAM. Here we disable
+  ;; the handler that causes that fault (SB-EXT:RUN-PROGRAM
+  ;; still works after that). Thanks to nyef on #lisp.
+  ;; See also: src/corelib/io/qprocess_unix.cpp in Qt
+  #+(and sbcl (not windows))
+  (sb-sys:enable-interrupt sb-unix:sigchld :default)
+  (cffi:load-foreign-library
+   (let ((lib (make-pathname :name #-windows "libcommonqt"
+                                   #+windows "commonqt"
+                             :type #+darwin "dylib"
+                                   #+windows "dll"
+                                   #-(or darwin windows) "so"
+                             :defaults #.(or *compile-file-truename*
+                                             *load-truename*))))
+     (if (probe-file lib)
+         (namestring lib)
+         (file-namestring lib))))
+  (setf *library-loaded-p* t))
 
 #-(or ecl ccl (and sbcl linkage-table))
 (load-libcommonqt)

--- a/info.lisp
+++ b/info.lisp
@@ -930,12 +930,7 @@
       (let ((idx *n-modules*))
         (unless (< idx (length *module-table*))
           (error "Sorry, +module-bits+ exceeded"))
-        (cffi:load-foreign-library
-        (format nil
-                #+darwin "libsmoke~A.dylib"
-                #+windows "smoke~A.dll"
-                #-(or windows darwin) "libsmoke~A.so"
-                name))
+        (qt-libs:ensure-lib-loaded (format NIL "smoke~a" name))
         (let ((init (cffi:foreign-symbol-pointer
                      (format nil "init_~A_Smoke" name))))
           (assert init)

--- a/info.lisp
+++ b/info.lisp
@@ -930,12 +930,7 @@
       (let ((idx *n-modules*))
         (unless (< idx (length *module-table*))
           (error "Sorry, +module-bits+ exceeded"))
-        (cffi:load-foreign-library
-        (format nil
-                #+darwin "libsmoke~A.dylib"
-                #+windows "smoke~A.dll"
-                #-(or windows darwin) "libsmoke~A.so"
-                name))
+        (load-library (format NIL "smoke~a" name))
         (let ((init (cffi:foreign-symbol-pointer
                      (format nil "init_~A_Smoke" name))))
           (assert init)

--- a/info.lisp
+++ b/info.lisp
@@ -915,8 +915,7 @@
   (fill *module-table* nil)
   (fill *module-data-table* nil)
   (setf *cached-objects* (make-hash-table))
-  (unless *library-loaded-p*
-    (load-libcommonqt))
+  (load-libcommonqt)
   (setf *loaded* t))
 
 (defun ensure-loaded ()
@@ -927,10 +926,17 @@
   (ensure-loaded)
   (let ((name (string-downcase name)))
     (unless (named-module-number name)
+      (unless (< *n-modules* (length *module-table*))
+        (error "Sorry, +module-bits+ exceeded"))
+      (load-library (format NIL "smoke~a" name))
+      (initialize-smoke name))))
+
+(defun initialize-smoke (name)
+  (let ((name (string-downcase name)))
+    (unless (named-module-number name)
       (let ((idx *n-modules*))
         (unless (< idx (length *module-table*))
           (error "Sorry, +module-bits+ exceeded"))
-        (load-library (format NIL "smoke~a" name))
         (let ((init (cffi:foreign-symbol-pointer
                      (format nil "init_~A_Smoke" name))))
           (assert init)

--- a/info.lisp
+++ b/info.lisp
@@ -930,7 +930,12 @@
       (let ((idx *n-modules*))
         (unless (< idx (length *module-table*))
           (error "Sorry, +module-bits+ exceeded"))
-        (qt-libs:ensure-lib-loaded (format NIL "smoke~a" name))
+        (cffi:load-foreign-library
+        (format nil
+                #+darwin "libsmoke~A.dylib"
+                #+windows "smoke~A.dll"
+                #-(or windows darwin) "libsmoke~A.so"
+                name))
         (let ((init (cffi:foreign-symbol-pointer
                      (format nil "init_~A_Smoke" name))))
           (assert init)

--- a/info.lisp
+++ b/info.lisp
@@ -923,15 +923,12 @@
     (reload)))
 
 (defun ensure-smoke (name)
-  (ensure-loaded)
   (let ((name (string-downcase name)))
-    (unless (named-module-number name)
-      (unless (< *n-modules* (length *module-table*))
-        (error "Sorry, +module-bits+ exceeded"))
-      (load-library (format NIL "smoke~a" name))
-      (initialize-smoke name))))
+    (load-library (format NIL "smoke~a" name))
+    (initialize-smoke name)))
 
 (defun initialize-smoke (name)
+  (ensure-loaded)
   (let ((name (string-downcase name)))
     (unless (named-module-number name)
       (let ((idx *n-modules*))

--- a/package.lisp
+++ b/package.lisp
@@ -28,10 +28,13 @@
 
 (defpackage :qt
   (:use :cl :iterate)
-  (:export #:ensure-smoke
+  (:export #:*load-library-function*
+           #:load-library
+           #:ensure-smoke
            #:qapropos
            #:qdescribe
            #:*qapplication*
+           #:*qapplication-create-hooks*
            #:make-qapplication
            #:interpret-call
            #:interpret-call-without-override

--- a/qapp.lisp
+++ b/qapp.lisp
@@ -58,9 +58,7 @@
            (setf *qapplication*
                  (if (null-qobject-p instance)
                      (%make-qapplication (cons "argv0dummy" args))
-                     instance))
-           (qt-libs:fix-qt-plugin-paths)
-           *qapplication*))))
+                     instance))))))
 
 (defun %make-qapplication (args &optional (guip t))
   (unless args

--- a/qapp.lisp
+++ b/qapp.lisp
@@ -40,6 +40,7 @@
 ;;; For example, "-display" "foo" will have been removed afterwards.
 
 (defvar *qapplication* nil)
+(defvar *qapplication-create-hooks* ())
 
 (defmacro with-main-window ((window form) &body body)
   `(progn
@@ -58,7 +59,10 @@
            (setf *qapplication*
                  (if (null-qobject-p instance)
                      (%make-qapplication (cons "argv0dummy" args))
-                     instance))))))
+                     instance)))
+         (dolist (hook *qapplication-create-hooks*)
+           (funcall hook *qapplication*))
+         *qapplication*)))
 
 (defun %make-qapplication (args &optional (guip t))
   (unless args

--- a/qapp.lisp
+++ b/qapp.lisp
@@ -58,7 +58,9 @@
            (setf *qapplication*
                  (if (null-qobject-p instance)
                      (%make-qapplication (cons "argv0dummy" args))
-                     instance))))))
+                     instance))
+           (qt-libs:fix-qt-plugin-paths)
+           *qapplication*))))
 
 (defun %make-qapplication (args &optional (guip t))
   (unless args

--- a/qt+libs.asd
+++ b/qt+libs.asd
@@ -1,0 +1,28 @@
+(defsystem :qt+libs
+  :description "Interface for the Qt GUI framework (precompiled libraries)"
+  :license "BSD"
+  :serial t
+  :components
+  ((:file "package")
+   (:file "utils")
+   (:file "ffi")
+   (:file "reader")
+   (:file "meta-classes")
+   (:file "classes")
+   (:file "info")
+   (:file "marshal")
+   (:file "unmarshal")
+   (:file "primitive-call")
+   (:file "call")
+   (:file "meta")
+   (:file "qvariant")
+   (:file "property")
+   (:file "qlist")
+   (:file "qapp")
+   (:file "connect")
+   (:file "qt-libs"))
+  :defsystem-depends-on (:trivial-features)
+  :depends-on (:cffi :named-readtables :cl-ppcre :alexandria
+               :closer-mop :qt-libs
+               :iterate :trivial-garbage
+               (:feature :darwin :bordeaux-threads)))

--- a/qt-libs.lisp
+++ b/qt-libs.lisp
@@ -1,0 +1,39 @@
+;;; -*- show-trailing-whitespace: t; indent-tabs-mode: nil -*-
+
+;;; Copyright (c) 2009 David Lichteblau. All rights reserved.
+
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :qt)
+(named-readtables:in-readtable :qt)
+
+(defun fix-qt-plugin-paths (qapplication)
+  (declare (ignore qapplication))
+  (#_QCoreApplication::setLibraryPaths
+   (list (uiop:native-namestring (merge-pathnames "plugins/" qt-libs:*standalone-libs-dir*)))))
+
+(push 'fix-qt-plugin-paths *qapplication-create-hooks*)
+
+(setf *load-library-function* 'qt-libs:ensure-lib-loaded)

--- a/qt.asd
+++ b/qt.asd
@@ -1,29 +1,102 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (asdf:oos 'asdf:load-op :trivial-features))
 
+;;; .cpp
+
+(defclass cpp->so (source-file)
+  ())
+
+(defmethod source-file-type ((c cpp->so) (s module)) "cpp")
+
+(defmethod output-files ((operation compile-op) (c cpp->so))
+  (values
+   (list (make-pathname :name "libcommonqt"
+                        :type #-darwin "so" #+darwin "dylib"
+                        :defaults (component-pathname c)))
+   ;; libcommonqt.so* files are never moved to separate FASL directory
+   t))
+
+(defmethod perform ((o load-op) (c cpp->so))
+  t)
+
+(defmethod perform ((o compile-op) (c cpp->so))
+  (when (find-package :qt)
+    (set (find-symbol (symbol-name '*loaded*) :qt) nil))
+  (unless (zerop (run-shell-command
+                  "if which gmake; then gmake -C ~S; else make -C ~:*~S; fi ~
+                   && touch ~s"
+                  (namestring
+                   (make-pathname :name nil
+                                  :type nil
+                                  :defaults (component-pathname c)))
+                  (namestring (car (output-files o c)))))
+    (error 'operation-error :component c :operation o)))
+
+;;; qmake
+
+(defclass makefile (source-file)
+  ())
+
+(defmethod source-file-type ((c makefile) (s module)) nil)
+
+(defmethod output-files ((operation compile-op) (c makefile))
+  (values (list (make-pathname :name "Makefile"
+                               :type nil
+                               :defaults (component-pathname c)))
+          t))
+
+(defmethod perform ((o load-op) (c makefile))
+  t)
+
+(defmethod perform ((o compile-op) (c makefile))
+  (when (find-package :qt)
+    (set (find-symbol (symbol-name '*loaded*) :qt) nil))
+  (unless (zerop (run-shell-command
+                  "command -v qmake-qt4 || command -v qmake"))
+    (error "No qmake found."))
+  (unless (zerop (run-shell-command
+                  "`command -v qmake-qt4 || command -v qmake` ~A~S -o ~S"
+                  #+darwin "-spec macx-g++ " #-darwin ""
+                  (namestring (component-pathname c))
+                  (namestring (output-file o c))))
+    (error 'operation-error :component c :operation o)))
+
+;;; system
+
 (defsystem :qt
   :description "Interface for the Qt GUI framework"
   :license "BSD"
-  :serial t
   :components
-  ((:file "package")
-   (:file "utils")
-   (:file "ffi")
-   (:file "reader")
-   (:file "meta-classes")
-   (:file "classes")
-   (:file "info")
-   (:file "marshal")
-   (:file "unmarshal")
-   (:file "primitive-call")
-   (:file "call")
-   (:file "meta")
-   (:file "qvariant")
-   (:file "property")
-   (:file "qlist")
-   (:file "qapp")
-   (:file "connect"))
+  (#-windows
+   (:module "so"
+    :pathname ""
+    :serial t
+    :components
+    ((makefile "commonqt.pro")
+     (:static-file "commonqt.h")
+     (cpp->so "commonqt" :depends-on ("commonqt.h"))))
+   (:module "lisp"
+    :pathname ""
+    :serial t
+    :components
+    ((:file "package")
+     (:file "utils")
+     (:file "ffi")
+     (:file "reader")
+     (:file "meta-classes")
+     (:file "classes")
+     (:file "info")
+     (:file "marshal")
+     (:file "unmarshal")
+     (:file "primitive-call")
+     (:file "call")
+     (:file "meta")
+     (:file "qvariant")
+     (:file "property")
+     (:file "qlist")
+     (:file "qapp")
+     (:file "connect"))))
   :defsystem-depends-on (:trivial-features)
   :depends-on (:cffi :named-readtables :cl-ppcre :alexandria
-               :closer-mop :qt-libs
+               :closer-mop
                :iterate :trivial-garbage #+darwin :bordeaux-threads))

--- a/qt.asd
+++ b/qt.asd
@@ -1,102 +1,29 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (asdf:oos 'asdf:load-op :trivial-features))
 
-;;; .cpp
-
-(defclass cpp->so (source-file)
-  ())
-
-(defmethod source-file-type ((c cpp->so) (s module)) "cpp")
-
-(defmethod output-files ((operation compile-op) (c cpp->so))
-  (values
-   (list (make-pathname :name "libcommonqt"
-                        :type #-darwin "so" #+darwin "dylib"
-                        :defaults (component-pathname c)))
-   ;; libcommonqt.so* files are never moved to separate FASL directory
-   t))
-
-(defmethod perform ((o load-op) (c cpp->so))
-  t)
-
-(defmethod perform ((o compile-op) (c cpp->so))
-  (when (find-package :qt)
-    (set (find-symbol (symbol-name '*loaded*) :qt) nil))
-  (unless (zerop (run-shell-command
-                  "if which gmake; then gmake -C ~S; else make -C ~:*~S; fi ~
-                   && touch ~s"
-                  (namestring
-                   (make-pathname :name nil
-                                  :type nil
-                                  :defaults (component-pathname c)))
-                  (namestring (car (output-files o c)))))
-    (error 'operation-error :component c :operation o)))
-
-;;; qmake
-
-(defclass makefile (source-file)
-  ())
-
-(defmethod source-file-type ((c makefile) (s module)) nil)
-
-(defmethod output-files ((operation compile-op) (c makefile))
-  (values (list (make-pathname :name "Makefile"
-                               :type nil
-                               :defaults (component-pathname c)))
-          t))
-
-(defmethod perform ((o load-op) (c makefile))
-  t)
-
-(defmethod perform ((o compile-op) (c makefile))
-  (when (find-package :qt)
-    (set (find-symbol (symbol-name '*loaded*) :qt) nil))
-  (unless (zerop (run-shell-command
-                  "command -v qmake-qt4 || command -v qmake"))
-    (error "No qmake found."))
-  (unless (zerop (run-shell-command
-                  "`command -v qmake-qt4 || command -v qmake` ~A~S -o ~S"
-                  #+darwin "-spec macx-g++ " #-darwin ""
-                  (namestring (component-pathname c))
-                  (namestring (output-file o c))))
-    (error 'operation-error :component c :operation o)))
-
-;;; system
-
 (defsystem :qt
   :description "Interface for the Qt GUI framework"
   :license "BSD"
+  :serial t
   :components
-  (#-windows
-   (:module "so"
-    :pathname ""
-    :serial t
-    :components
-    ((makefile "commonqt.pro")
-     (:static-file "commonqt.h")
-     (cpp->so "commonqt" :depends-on ("commonqt.h"))))
-   (:module "lisp"
-    :pathname ""
-    :serial t
-    :components
-    ((:file "package")
-     (:file "utils")
-     (:file "ffi")
-     (:file "reader")
-     (:file "meta-classes")
-     (:file "classes")
-     (:file "info")
-     (:file "marshal")
-     (:file "unmarshal")
-     (:file "primitive-call")
-     (:file "call")
-     (:file "meta")
-     (:file "qvariant")
-     (:file "property")
-     (:file "qlist")
-     (:file "qapp")
-     (:file "connect"))))
+  ((:file "package")
+   (:file "utils")
+   (:file "ffi")
+   (:file "reader")
+   (:file "meta-classes")
+   (:file "classes")
+   (:file "info")
+   (:file "marshal")
+   (:file "unmarshal")
+   (:file "primitive-call")
+   (:file "call")
+   (:file "meta")
+   (:file "qvariant")
+   (:file "property")
+   (:file "qlist")
+   (:file "qapp")
+   (:file "connect"))
   :defsystem-depends-on (:trivial-features)
   :depends-on (:cffi :named-readtables :cl-ppcre :alexandria
-               :closer-mop
+               :closer-mop :qt-libs
                :iterate :trivial-garbage #+darwin :bordeaux-threads))

--- a/utils.lisp
+++ b/utils.lisp
@@ -29,6 +29,21 @@
 
 (in-package :qt)
 
+(defvar *load-library-function* 'simple-load-library)
+
+(defun simple-load-library (name)
+  (let ((path (make-pathname :name (format NIL #-windows "lib~a" #+windows "~a" name)
+                             :type #+darwin "dylib" #+windows "dll" #-(or darwin windows) "so"
+                             :defaults #.(or *compile-file-truename* *load-truename* *default-pathname-defaults*))))
+    (cffi:load-foreign-library
+     (if (probe-file path)
+         path
+         (file-namestring path)))))
+
+(defun load-library (name)
+  (funcall *load-library-function* name))
+
+
 ;; Cache the result of COMPILATION-BODY as long as KEYS still match.
 ;; This is thread-safe because the cache is replaced atomically.  We will
 ;; lose cache conses if threads replace them simultaneously.  But that's


### PR DESCRIPTION
This gets rid of a lot of gross hacks in qt-libs that were established to work around the previous CommonQt compilation and loading mechanisms (Shinmera/qt-libs@d8dfd9de8f233b81ced55a861988e0118297f640).

This will also make CommonQt a "quickload and forget" system by relying on qt-libs to automatically download precompiled, curated binaries of the foreign library dependencies, if the qt+libs system is used. The old qt system remains unchanged.

In order to test this you'll need to locally clone the current master of [qt-libs](https://github.com/Shinmera/qt-libs).