### PR TITLE
Don't use LOAD-LIBCOMMONQT on Allegro either

### DIFF
--- a/ffi.lisp
+++ b/ffi.lisp
@@ -36,7 +36,7 @@
     (load-library "commonqt")
     (setf *library-loaded-p* t)))
 
-#-(or ecl ccl (and sbcl linkage-table))
+#-(or ecl ccl (and sbcl linkage-table) allegro)
 (load-libcommonqt)
 
 (defmacro defcfun (name ret &rest args)


### PR DESCRIPTION
I don't quite understand what the criteria for invoking `load-libcommonqt` are but qt-libs works on Allegro CL too starting with https://github.com/Shinmera/qt-libs/commit/b39b910f278dea598a9d0915eeba2fb0182e0db6

