### PR TITLE
Specify foreign string encodings everywhere

### DIFF
--- a/call.lisp
+++ b/call.lisp
@@ -253,7 +253,7 @@
      for elt across vector
      do
        (setf (cffi:mem-aref ptr :pointer i)
-             (cffi:foreign-string-alloc elt))))
+             (cffi:foreign-string-alloc elt :encoding :utf-8))))
 
 (defun string-vector-to-char** (vector)
   (let ((ptr (cffi:foreign-alloc :pointer :count (length vector))))
@@ -265,7 +265,7 @@
      for i from 0 below n
      do
        (setf (elt vector i)
-             (cffi:mem-aref ptr :string i))
+             (cffi:mem-aref ptr '(:string :encoding :utf-8) i))
        (when freep
          (cffi:foreign-free (cffi:mem-aref ptr :pointer i)))))
 

--- a/ffi.lisp
+++ b/ffi.lisp
@@ -58,13 +58,13 @@
   (qvector-uint :pointer))
 
 (defcfun "sw_make_qbytearray" :pointer
-  (str :string))
+  (str (:string :encoding :utf-8)))
 
 (defcfun "sw_delete_qbytearray" :void
-  (str :string))
+  (str :pointer))
 
 (defcfun "sw_make_qstring" :pointer
-  (str :string))
+  (str (:string :encoding :utf-8)))
 
 (defcfun "sw_delete_qstring" :void
   (qstring :pointer))
@@ -76,7 +76,7 @@
 
 (defcfun "sw_qstringlist_append" :void
   (qstringlist :pointer)
-  (str :string))
+  (str (:string :encoding :utf-8)))
 
 (defcfun "sw_qstringlist_size" :int
   (qstringlist :pointer))
@@ -123,10 +123,10 @@
 
 (defcfun "sw_find_name" :short
   (smoke :pointer)
-  (str :string))
+  (str (:string :encoding :ascii)))
 
 (defcfun "sw_find_class" :void
-  (name :string)
+  (name (:string :encoding :ascii))
   (smoke** :pointer)
   (index** :pointer))
 
@@ -137,11 +137,11 @@
 
 (defcfun "sw_id_type" :short
   (smoke :pointer)
-  (name :string))
+  (name (:string :encoding :ascii)))
 
 (defcfun "sw_id_class" :short
   (smoke :pointer)
-  (name :string)
+  (name (:string :encoding :ascii))
   (external :char))                     ;bool
 
 (defcfun "sw_id_instance_class" :short
@@ -193,7 +193,7 @@
   (define-qlist-marshaller-funcs extraselection))
 
 (cffi:defcstruct SmokeData
-  (name :string)
+  (name (:string :encoding :ascii))
   (classes :pointer)
   (nclasses :short)
   (methods :pointer)
@@ -263,7 +263,7 @@
   (methodid :short))
 
 (cffi:defcstruct qClass
-  (className :string)
+  (className (:string :encoding :ascii))
   (external :char)
   (parents :short)
   (classfn :pointer) ;; void (*classfn)(Index method, void *obj, Stack args)
@@ -272,7 +272,7 @@
   (size :unsigned-int))
 
 (cffi:defcstruct qType
-  (name :string)
+  (name (:string :encoding :ascii))
   (classid :short)
   (flags :short))
 

--- a/info.lisp
+++ b/info.lisp
@@ -374,7 +374,7 @@
   (declare (type module-number <module>))
   (declare (type index idx))
   (cffi:mem-aref (data-methodnames (data-ref <module>))
-                 :string
+                 '(:string :encoding :ascii)
                  idx))
 
 (declaim (inline methodmap-name-index))

--- a/marshal.lisp
+++ b/marshal.lisp
@@ -214,13 +214,13 @@
   (funcall cont (sw_make_qstring value)))
 
 (defmarshal (value (:|unsigned char*| :|const char*|) :around cont :type string)
-  (let ((char* (cffi:foreign-string-alloc value)))
+  (let ((char* (cffi:foreign-string-alloc value :encoding :utf-8)))
     (unwind-protect
          (funcall cont char*)
       (cffi:foreign-free char*))))
 
 (defmarshal-override (value (:|unsigned char*| :|const char*|) :type string)
-  (cffi:foreign-string-alloc value))
+  (cffi:foreign-string-alloc value :encoding :utf-8))
 
 (defmarshal (value (:|QByteArray| :|const QByteArray&|) :around cont :type string)
   (let ((qbytearray (sw_make_qbytearray value)))

--- a/meta.lisp
+++ b/meta.lisp
@@ -399,5 +399,5 @@ Should be used as an optimization."
                      :class (find-qclass "QMetaObject")
                      :pointer
                      (sw_make_metaobject (qobject-pointer parent)
-                                         (cffi:foreign-string-alloc signature)
+                                         (cffi:foreign-string-alloc signature :encoding :ascii)
                                          dataptr)))))

--- a/qlist.lisp
+++ b/qlist.lisp
@@ -7,7 +7,7 @@
     (unwind-protect
          (progn
            (dolist (str value)
-             (let ((char* (cffi:foreign-string-alloc str)))
+             (let ((char* (cffi:foreign-string-alloc str :encoding :utf-8)))
                (unwind-protect
                     (sw_qstringlist_append qstringlist char*)
                  (cffi:foreign-free char*))))

--- a/unmarshal.lisp
+++ b/unmarshal.lisp
@@ -126,7 +126,7 @@
                              fdefinition)))))))
 
 (def-unmarshal (value "char*" type)
-  (cffi:foreign-string-to-lisp value))
+  (cffi:foreign-string-to-lisp value :encoding :utf-8))
 
 (def-unmarshal (value "void**" type)
   value)


### PR DESCRIPTION
Don't depend on `cffi:*default-foreign-encoding*` (which defaults to
`:utf-8`) which may change at runtime.