### PR TITLE
Protect concurrent accesses to *CACHED-OBJECTS*

### DIFF
--- a/qt-test.asd
+++ b/qt-test.asd
@@ -11,4 +11,4 @@
     :components ((:file "package")
                  (:file "tests")
                  (:file "microbench"))
-    :depends-on (:qt :alexandria :iterate :trivial-garbage :rt))
+    :depends-on (:qt :alexandria :iterate :trivial-garbage :rt :bordeaux-threads))

--- a/qt.asd
+++ b/qt.asd
@@ -99,4 +99,5 @@
   :defsystem-depends-on (:trivial-features)
   :depends-on (:cffi :named-readtables :cl-ppcre :alexandria
                :closer-mop
-               :iterate :trivial-garbage #+darwin :bordeaux-threads))
+	       :iterate :trivial-garbage
+	       #+(or darwin (not (or sbcl ccl))) :bordeaux-threads))

--- a/test/tests.lisp
+++ b/test/tests.lisp
@@ -537,3 +537,12 @@
                      (enum= e r)
                      (equal e r))))
   t)
+
+(deftest/qt multithreading
+    (flet ((make-events ()
+	     (ignore-errors
+	      (loop repeat 10000 do (#_delete (#_new QEvent (#_QEvent::User))))
+	      t)))
+      (let ((threads (loop repeat 20 collect (bt:make-thread #'make-events))))
+	(notany #'null (mapcar #'bt:join-thread threads))))
+  t)


### PR DESCRIPTION
Although most Qt objects are created in the main GUI thread, many
others can be created in secondary threads, notably QEvents. Use
synchronized hash-tables on SBCL and CCL and explicit locks elsewhere.